### PR TITLE
Cleanup readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,9 @@ $ godep restore
 
 Expose a pprof endpoint. Official Go docs are [here](https://golang.org/pkg/net/http/pprof/). If your application is already running a server on the DefaultServeMux, just add this import to your application.
 
-```
+```go
 import _ "net/http/pprof"
 ```
-
-If your application is not using the DefaultServeMux, you can still easily expose pprof endpoints.
 
 ## Run the Tests
 


### PR DESCRIPTION
The sentence about the DefaultServeMux used to point to an internal
implementation, which we removed. This sentence no longer makes sense by
itself. People can follow the documentation on the pprof page to install
it for a non-default serve mux.
