### PR TITLE
Added logic to detect and ignore cycles in input call graph.

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -56,6 +56,7 @@ type searchArgs struct {
 	nodeToOutEdges map[string][]*ggv.Edge
 	nameToNodes    map[string]*ggv.Node
 	buffer         *bytes.Buffer
+	colorMap       map[string]color
 }
 
 type searcher interface {
@@ -78,6 +79,19 @@ type pathStringer interface {
 }
 
 type defaultPathStringer struct{}
+
+// Marking colors during dfs is a standard way of detecting cycles.
+// A node is white before it has been discovered, gray when it is on the recursion stack, and black
+// when all of its neighbors have been traversed. A edge terminating at a grey edge implies a back
+// edge, which also implies a cycle
+// (see: https://en.wikipedia.org/wiki/Cycle_(graph_theory)#Cycle_detection).
+type color int
+
+const (
+	WHITE color = iota
+	GRAY
+	BLACK
+)
 
 // NewGrapher returns a default grapher struct with default attributes
 func NewGrapher() Grapher {
@@ -111,6 +125,7 @@ func (g *defaultGrapher) GraphAsText(dotText []byte) (string, error) {
 	nameToNodes := dag.Nodes.Lookup
 
 	buffer := new(bytes.Buffer)
+	colorMap := make(map[string]color)
 
 	for _, root := range inDegreeZeroNodes {
 		g.searcher.dfs(searchArgs{
@@ -119,8 +134,10 @@ func (g *defaultGrapher) GraphAsText(dotText []byte) (string, error) {
 			nodeToOutEdges: nodeToOutEdges,
 			nameToNodes:    nameToNodes,
 			buffer:         buffer,
+			colorMap:       colorMap,
 		})
 	}
+
 	return buffer.String(), nil
 }
 
@@ -155,15 +172,25 @@ func (c *defaultCollectionGetter) getInDegreeZeroNodes(dag *ggv.Graph) []string 
 	return inDegreeZeroNodes
 }
 
+var Count int
+
 // dfs performs a depth-first search traversal of the graph starting from a
 // given root node. When a node with no outgoing edges is reached, the path
 // taken to that node is written to a buffer.
 func (s *defaultSearcher) dfs(args searchArgs) {
 	outEdges := args.nodeToOutEdges[args.root]
-	if len(outEdges) == 0 {
-		args.buffer.WriteString(s.pathStringer.pathAsString(args.path, args.nameToNodes))
+	if args.colorMap[args.root] == GRAY {
+		logrus.Warn("The input call graph contains a cycle. This can't be represented in a " +
+			"flame graph, so this path will be ignored. For your record, the ignored path " +
+			"is:\n" + strings.TrimSpace(s.pathStringer.pathAsString(args.path, args.nameToNodes)))
 		return
 	}
+	if len(outEdges) == 0 {
+		args.buffer.WriteString(s.pathStringer.pathAsString(args.path, args.nameToNodes))
+		args.colorMap[args.root] = BLACK
+		return
+	}
+	args.colorMap[args.root] = GRAY
 	for _, edge := range outEdges {
 		s.dfs(searchArgs{
 			root:           edge.Dst,
@@ -171,8 +198,10 @@ func (s *defaultSearcher) dfs(args searchArgs) {
 			nodeToOutEdges: args.nodeToOutEdges,
 			nameToNodes:    args.nameToNodes,
 			buffer:         args.buffer,
+			colorMap:       args.colorMap,
 		})
 	}
+	args.colorMap[args.root] = BLACK
 }
 
 // pathAsString takes a path and a mapping of node names to node structs and

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -80,7 +80,7 @@ type pathStringer interface {
 
 type defaultPathStringer struct{}
 
-// Marking colors during dfs is a standard way of detecting cycles.
+// Marking colors during depth-first search is a standard way of detecting cycles.
 // A node is white before it has been discovered, gray when it is on the recursion stack, and black
 // when all of its neighbors have been traversed. A edge terminating at a grey edge implies a back
 // edge, which also implies a cycle
@@ -171,8 +171,6 @@ func (c *defaultCollectionGetter) getInDegreeZeroNodes(dag *ggv.Graph) []string 
 	}
 	return inDegreeZeroNodes
 }
-
-var Count int
 
 // dfs performs a depth-first search traversal of the graph starting from a
 // given root node. When a node with no outgoing edges is reached, the path

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -56,7 +56,7 @@ type searchArgs struct {
 	nodeToOutEdges map[string][]*ggv.Edge
 	nameToNodes    map[string]*ggv.Node
 	buffer         *bytes.Buffer
-	colorMap       map[string]color
+	statusMap      map[string]discoveryStatus
 }
 
 type searcher interface {
@@ -80,17 +80,17 @@ type pathStringer interface {
 
 type defaultPathStringer struct{}
 
-// Marking colors during depth-first search is a standard way of detecting cycles.
-// A node is white before it has been discovered, gray when it is on the recursion stack, and black
-// when all of its neighbors have been traversed. A edge terminating at a grey edge implies a back
-// edge, which also implies a cycle
+// Marking nodes during depth-first search is a standard way of detecting cycles.
+// A node is UNDISCOVERED before it has been discovered, ONSTACK when it is on the recursion stack,
+// and DISCOVERED when all of its neighbors have been traversed. A edge terminating at a ONSTACK
+// node implies a back edge, which also implies a cycle
 // (see: https://en.wikipedia.org/wiki/Cycle_(graph_theory)#Cycle_detection).
-type color int
+type discoveryStatus int
 
 const (
-	WHITE color = iota
-	GRAY
-	BLACK
+	UNDISCOVERED discoveryStatus = iota
+	ONSTACK
+	DISCOVERED
 )
 
 // NewGrapher returns a default grapher struct with default attributes
@@ -125,7 +125,7 @@ func (g *defaultGrapher) GraphAsText(dotText []byte) (string, error) {
 	nameToNodes := dag.Nodes.Lookup
 
 	buffer := new(bytes.Buffer)
-	colorMap := make(map[string]color)
+	statusMap := make(map[string]discoveryStatus)
 
 	for _, root := range inDegreeZeroNodes {
 		g.searcher.dfs(searchArgs{
@@ -134,7 +134,7 @@ func (g *defaultGrapher) GraphAsText(dotText []byte) (string, error) {
 			nodeToOutEdges: nodeToOutEdges,
 			nameToNodes:    nameToNodes,
 			buffer:         buffer,
-			colorMap:       colorMap,
+			statusMap:      statusMap,
 		})
 	}
 
@@ -177,7 +177,7 @@ func (c *defaultCollectionGetter) getInDegreeZeroNodes(dag *ggv.Graph) []string 
 // taken to that node is written to a buffer.
 func (s *defaultSearcher) dfs(args searchArgs) {
 	outEdges := args.nodeToOutEdges[args.root]
-	if args.colorMap[args.root] == GRAY {
+	if args.statusMap[args.root] == ONSTACK {
 		logrus.Warn("The input call graph contains a cycle. This can't be represented in a " +
 			"flame graph, so this path will be ignored. For your record, the ignored path " +
 			"is:\n" + strings.TrimSpace(s.pathStringer.pathAsString(args.path, args.nameToNodes)))
@@ -185,10 +185,10 @@ func (s *defaultSearcher) dfs(args searchArgs) {
 	}
 	if len(outEdges) == 0 {
 		args.buffer.WriteString(s.pathStringer.pathAsString(args.path, args.nameToNodes))
-		args.colorMap[args.root] = BLACK
+		args.statusMap[args.root] = DISCOVERED
 		return
 	}
-	args.colorMap[args.root] = GRAY
+	args.statusMap[args.root] = ONSTACK
 	for _, edge := range outEdges {
 		s.dfs(searchArgs{
 			root:           edge.Dst,
@@ -196,10 +196,10 @@ func (s *defaultSearcher) dfs(args searchArgs) {
 			nodeToOutEdges: args.nodeToOutEdges,
 			nameToNodes:    args.nameToNodes,
 			buffer:         args.buffer,
-			colorMap:       args.colorMap,
+			statusMap:      args.statusMap,
 		})
 	}
-	args.colorMap[args.root] = BLACK
+	args.statusMap[args.root] = DISCOVERED
 }
 
 // pathAsString takes a path and a mapping of node names to node structs and

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -88,7 +88,7 @@ func TestDFS(t *testing.T) {
 		nodeToOutEdges: nodeToOutEdges,
 		nameToNodes:    g.Nodes.Lookup,
 		buffer:         buffer,
-		colorMap:       make(map[string]color),
+		statusMap:      make(map[string]discoveryStatus),
 	})
 
 	correctOutput := "N1;N2;N3 3\nN1;N3 2\nN1;N4;N3 8\n"
@@ -121,7 +121,7 @@ func TestDFSAlmostEmptyGraph(t *testing.T) {
 		nodeToOutEdges: nodeToOutEdges,
 		nameToNodes:    g.Nodes.Lookup,
 		buffer:         buffer,
-		colorMap:       make(map[string]color),
+		statusMap:      make(map[string]discoveryStatus),
 	})
 
 	correctOutput := ""
@@ -165,7 +165,7 @@ func TestDFSMultipleRootsLeaves(t *testing.T) {
 		nodeToOutEdges: nodeToOutEdges,
 		nameToNodes:    g.Nodes.Lookup,
 		buffer:         buffer,
-		colorMap:       make(map[string]color),
+		statusMap:      make(map[string]discoveryStatus),
 	})
 	searcherWithTestStringer.dfs(searchArgs{
 		root:           "N4",
@@ -173,7 +173,7 @@ func TestDFSMultipleRootsLeaves(t *testing.T) {
 		nodeToOutEdges: nodeToOutEdges,
 		nameToNodes:    g.Nodes.Lookup,
 		buffer:         buffer,
-		colorMap:       make(map[string]color),
+		statusMap:      make(map[string]discoveryStatus),
 	})
 
 	correctOutput := "N1;N2 3\nN1;N3 2\nN4;N5 8\nN4;N6;N5 7\n"
@@ -219,7 +219,7 @@ func TestDFSCyclicGraph(t *testing.T) {
 		nodeToOutEdges: nodeToOutEdges,
 		nameToNodes:    g.Nodes.Lookup,
 		buffer:         buffer,
-		colorMap:       make(map[string]color),
+		statusMap:      make(map[string]discoveryStatus),
 	})
 
 	correctOutput := "N1;N2;N3;N4 4\nN2;N4 2\nN1;N4 2\n"


### PR DESCRIPTION
Sometimes, there can be cycles in the call graph. Cycles don't really make sense in a flame graph, so I ignore them for now.

I detect cycles by "coloring" nodes. From the code:

```
// Marking colors during dfs is a standard way of detecting cycles.
// A node is white before it has been discovered, gray when it is on the recursion stack, and black
// when all of its neighbors have been traversed. A edge terminating at a grey edge implies a back
// edge, which also implies a cycle
// (see: https://en.wikipedia.org/wiki/Cycle_(graph_theory)#Cycle_detection).
```
