### PR TITLE
Directly link to flame graph svg in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ synthesizes them into into a flame graph. Uses Go's built in pprof library.
 
 ## Example Flame Graph
 
-![Inception](http://uber.github.io/go-torch/meta.svg)
+[![Inception](http://uber.github.io/go-torch/meta.svg)](http://uber.github.io/go-torch/meta.svg)
 
 ## Basic Usage
 


### PR DESCRIPTION
Before, the README linked to some cached version of the svg which did not include all interactivity. Now, the actual svg at http://uber.github.io/go-torch/meta.svg is linked to.