### PR TITLE
pprof requires binary as well as pprof output when using files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ GLOBAL OPTIONS:
    --url, -u "http://localhost:8080"   base url of your Go program
    --suffix, -s "/debug/pprof/profile" url path of pprof profile
    --binaryinput, -b          file path of raw binary profile; alternative to having go-torch query pprof endpoint (binary profile is anything accepted by https://golang.org/cmd/pprof)
+   --binaryname               file path of the binary that the binaryinput is for, used for pprof inputs
    --time, -t "30"         time in seconds to profile for
    --file, -f "torch.svg"     ouput file name (must be .svg)
    --print, -p          print the generated svg to stdout instead of writing to file
@@ -63,6 +64,16 @@ INFO[0000] Profiling ...
 function1;function2 3
 ...
 INFO[0015] raw call graph output been printed to stdout
+```
+
+### Local pprof Example
+
+```
+$ go test -cpuprofile=cpu.pprof
+# This creates a cpu.pprof file, and the golang.test binary.
+$ go-torch --binaryfile cpu.pprof --binaryname golang.test
+INFO[0000] Profiling ...
+INFO[0000] flame graph has been created as torch.svg
 ```
 
 ## Installation

--- a/main_test.go
+++ b/main_test.go
@@ -57,9 +57,10 @@ func TestCreateAndRunAppDefaultValues(t *testing.T) {
 		assert.Equal(t, "/debug/pprof/profile", context.String("suffix"))
 		assert.Equal(t, "torch.svg", context.String("file"))
 		assert.Equal(t, "", context.String("binaryinput"))
+		assert.Equal(t, "", context.String("binaryname"))
 		assert.Equal(t, false, context.Bool("print"))
 		assert.Equal(t, false, context.Bool("raw"))
-		assert.Equal(t, 9, len(context.App.Flags))
+		assert.Equal(t, 10, len(context.App.Flags))
 	}
 	mockCommander.On("goTorchCommand", mock.AnythingOfType(
 		"*cli.Context")).Return().Run(validateDefaults)
@@ -82,7 +83,7 @@ func TestGoTorchCommand(t *testing.T) {
 
 	mockValidator.On("validateArgument", "torch.svg", `\w+\.svg`,
 		"Output file name must be .svg").Return(nil).Once()
-	mockPprofer.On("runPprofCommand", 30, "http://localhost/hi").Return(samplePprofOutput, nil).Once()
+	mockPprofer.On("runPprofCommand", []string{"-seconds", "30", "http://localhost/hi"}).Return(samplePprofOutput, nil).Once()
 	mockGrapher.On("GraphAsText", samplePprofOutput).Return("1;2;3 3", nil).Once()
 	mockVisualizer.On("GenerateFlameGraph", "1;2;3 3", "torch.svg", false).Return(nil).Once()
 
@@ -108,7 +109,7 @@ func TestGoTorchCommandRawOutput(t *testing.T) {
 	samplePprofOutput := []byte("out")
 	mockValidator.On("validateArgument", "torch.svg", `\w+\.svg`,
 		"Output file name must be .svg").Return(nil).Once()
-	mockPprofer.On("runPprofCommand", 30, "http://localhost/hi").Return(samplePprofOutput, nil).Once()
+	mockPprofer.On("runPprofCommand", []string{"-seconds", "30", "http://localhost/hi"}).Return(samplePprofOutput, nil).Once()
 	mockGrapher.On("GraphAsText", samplePprofOutput).Return("1;2;3 3", nil).Once()
 
 	createSampleContextForRaw(commander)
@@ -133,7 +134,7 @@ func TestGoTorchCommandBinaryInput(t *testing.T) {
 	samplePprofOutput := []byte("out")
 	mockValidator.On("validateArgument", "torch.svg", `\w+\.svg`,
 		"Output file name must be .svg").Return(nil).Once()
-	mockPprofer.On("runPprofCommand", 30, "/path/to/binary/input").Return(samplePprofOutput, nil).Once()
+	mockPprofer.On("runPprofCommand", []string{"/path/to/binary/file", "/path/to/binary/input"}).Return(samplePprofOutput, nil).Once()
 	mockGrapher.On("GraphAsText", samplePprofOutput).Return("1;2;3 3", nil).Once()
 	mockVisualizer.On("GenerateFlameGraph", "1;2;3 3", "torch.svg", false).Return(nil).Once()
 
@@ -224,6 +225,10 @@ func createSampleContextForBinaryInput(commander *defaultCommander) {
 		cli.StringFlag{
 			Name:  "binaryinput, b",
 			Value: "/path/to/binary/input",
+		},
+		cli.StringFlag{
+			Name:  "binaryname",
+			Value: "/path/to/binary/file",
 		},
 		cli.IntFlag{
 			Name:  "time, t",

--- a/mocks.go
+++ b/mocks.go
@@ -74,8 +74,8 @@ type mockPprofer struct {
 	mock.Mock
 }
 
-func (m *mockPprofer) runPprofCommand(_a0 int, _a1 string) ([]byte, error) {
-	ret := m.Called(_a0, _a1)
+func (m *mockPprofer) runPprofCommand(args ...string) ([]byte, error) {
+	ret := m.Called(args)
 
 	var r0 []byte
 	if ret.Get(0) != nil {


### PR DESCRIPTION
from pprof usage:
  usage: pprof [options] [binary] <profile source> ...

require a binaryname arg when using binaryfile.
verified this with local -cpuprofile output from tests.

r @sandlerben 