### PR TITLE
Use url.URL to create the pprof URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"regexp"
@@ -157,7 +158,6 @@ func (t *torcher) createAndRunApp() {
 
 // goTorchCommand executes the 'go-torch' command.
 func (com *defaultCommander) goTorchCommand(c *cli.Context) {
-	url := c.String("url") + c.String("suffix")
 	outputFile := c.String("file")
 	binaryName := c.String("binaryname")
 	binaryInput := c.String("binaryinput")
@@ -179,7 +179,12 @@ func (com *defaultCommander) goTorchCommand(c *cli.Context) {
 		}
 		pprofArgs = append(pprofArgs, binaryInput)
 	} else {
-		pprofArgs = []string{"-seconds", fmt.Sprint(time), url}
+		u, err := url.Parse(c.String("url"))
+		if err != nil {
+			log.Fatal(err)
+		}
+		u.Path = c.String("suffix")
+		pprofArgs = []string{"-seconds", fmt.Sprint(time), u.String()}
 	}
 
 	out, err := com.pprofer.runPprofCommand(pprofArgs...)

--- a/main_test.go
+++ b/main_test.go
@@ -69,7 +69,7 @@ func TestCreateAndRunAppDefaultValues(t *testing.T) {
 	torcher.createAndRunApp()
 }
 
-func TestGoTorchCommand(t *testing.T) {
+func testGoTorchCommand(t *testing.T, url string) {
 	mockValidator := new(mockValidator)
 	mockPprofer := new(mockPprofer)
 	mockGrapher := new(mockGrapher)
@@ -89,12 +89,19 @@ func TestGoTorchCommand(t *testing.T) {
 	mockGrapher.On("GraphAsText", samplePprofOutput).Return("1;2;3 3", nil).Once()
 	mockVisualizer.On("GenerateFlameGraph", "1;2;3 3", "torch.svg", false).Return(nil).Once()
 
-	createSampleContext(commander)
+	createSampleContext(commander, url)
 
 	mockValidator.AssertExpectations(t)
 	mockPprofer.AssertExpectations(t)
 	mockGrapher.AssertExpectations(t)
 	mockVisualizer.AssertExpectations(t)
+}
+
+func TestGoTorchCommand(t *testing.T) {
+	testGoTorchCommand(t, "http://localhost")
+
+	// Trailing slash in url should still work.
+	testGoTorchCommand(t, "http://localhost/")
 }
 
 func TestGoTorchCommandRawOutput(t *testing.T) {
@@ -220,13 +227,13 @@ func TestNewCommander(t *testing.T) {
 	assert.NotNil(t, newCommander())
 }
 
-func createSampleContext(commander *defaultCommander) {
+func createSampleContext(commander *defaultCommander, url string) {
 	app := cli.NewApp()
 	app.Name = "go-torch"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "url, u",
-			Value: "http://localhost",
+			Value: url,
 		},
 		cli.StringFlag{
 			Name:  "suffix, s",


### PR DESCRIPTION
To avoid issues like #20, we can use url.URL to create the final URL.

r @sandlerben 