### PR TITLE
Ignore location lines without function data.

### DIFF
--- a/pprof/parser.go
+++ b/pprof/parser.go
@@ -156,7 +156,10 @@ func (p *rawParser) toSamples() []*stack.Sample {
 func (p *rawParser) addLocation(line string) {
 	parts := splitBySpace(line)
 	if len(parts) < 4 {
-		p.setError(fmt.Errorf("malformed location line: %v", line))
+		// Do not error when there is only id and address in the line.
+		if len(parts) != 2 {
+			p.setError(fmt.Errorf("malformed location line: %v", line))
+		}
 		return
 	}
 	funcID := p.toFuncID(strings.TrimSuffix(parts[0], ":"))

--- a/pprof/parser_test.go
+++ b/pprof/parser_test.go
@@ -128,6 +128,28 @@ func TestParseMissingLocation(t *testing.T) {
 	}
 }
 
+func TestParseMissingSourceLine(t *testing.T) {
+	contents := `Samples:
+	samples/count cpu/nanoseconds
+	   2   10000000: 1 2
+	Locations:
+	   1: 0xaaaaa funcName :0 s=0
+	   2: 0xaaaab
+`
+	out, err := ParseRaw([]byte(contents))
+	if err != nil {
+		t.Fatalf("Missing location should not cause an error, got %v", err)
+	}
+
+	expected := []*stack.Sample{{
+		Funcs: []string{"missing-function-2", "funcName"},
+		Count: 2,
+	}}
+	if !reflect.DeepEqual(out, expected) {
+		t.Errorf("Missing function call stack should contain missing-function-2\n  got %+v\n want %+v", expected, out)
+	}
+}
+
 func testParseRawBad(t *testing.T, errorReason, errorSubstr, contents string) {
 	_, err := ParseRaw([]byte(contents))
 	if err == nil {


### PR DESCRIPTION
Locations only with ID and Address are valid. Torch should ignore them, since they don't include function information.

Example:

```
   648: 0x4cd061 runtime._ExternalCode :0 s=0
   649: 0x408401
```

See the source where those lines are added to the profile:

https://github.com/golang/go/blob/f78a4c84ac8ed44aaf331989aa32e40081fd8f13/src/cmd/pprof/internal/profile/profile.go#L386

Signed-off-by: David Calavera <david.calavera@gmail.com>