### PR TITLE
Support pprof arg format in go-torch

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,9 @@ func main() {
 
 func runWithArgs(args ...string) error {
 	opts := &options{}
-	if _, err := gflags.ParseArgs(opts, args); err != nil {
+
+	remaining, err := gflags.ParseArgs(opts, args)
+	if err != nil {
 		if flagErr, ok := err.(*gflags.Error); ok && flagErr.Type == gflags.ErrHelp {
 			os.Exit(0)
 		}
@@ -63,11 +65,15 @@ func runWithArgs(args ...string) error {
 		return fmt.Errorf("invalid options: %v", err)
 	}
 
-	return runWithOptions(opts)
+	// If there are remaining arguments, the first argument is the binary name.
+	if len(remaining) > 0 {
+		remaining = remaining[1:]
+	}
+	return runWithOptions(opts, remaining)
 }
 
-func runWithOptions(opts *options) error {
-	pprofRawOutput, err := pprof.GetRaw(opts.PProfOptions)
+func runWithOptions(opts *options, remaining []string) error {
+	pprofRawOutput, err := pprof.GetRaw(opts.PProfOptions, remaining)
 	if err != nil {
 		return fmt.Errorf("could not get raw output from pprof: %v", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -60,7 +60,13 @@ func TestBadArgs(t *testing.T) {
 }
 
 func TestMain(t *testing.T) {
-	os.Args = []string{"--raw", "--binaryinput", testPProfInputFile}
+	os.Args = []string{"go-torch", "--raw", "--binaryinput", testPProfInputFile}
+	main()
+	// Test should not fatal.
+}
+
+func TestMainRemaining(t *testing.T) {
+	os.Args = []string{"go-torch", "--raw", testPProfInputFile}
 	main()
 	// Test should not fatal.
 }
@@ -97,7 +103,7 @@ func TestRunRaw(t *testing.T) {
 	opts := getDefaultOptions()
 	opts.Raw = true
 
-	if err := runWithOptions(opts); err != nil {
+	if err := runWithOptions(opts, nil); err != nil {
 		t.Fatalf("Run with Raw failed: %v", err)
 	}
 }
@@ -117,7 +123,7 @@ func TestRunFile(t *testing.T) {
 	opts.File = getTempFilename(t, ".svg")
 
 	withScriptsInPath(t, func() {
-		if err := runWithOptions(opts); err != nil {
+		if err := runWithOptions(opts, nil); err != nil {
 			t.Fatalf("Run with Print failed: %v", err)
 		}
 
@@ -144,7 +150,7 @@ func TestRunBadFile(t *testing.T) {
 	opts.File = "/dev/zero/invalid/file"
 
 	withScriptsInPath(t, func() {
-		if err := runWithOptions(opts); err == nil {
+		if err := runWithOptions(opts, nil); err == nil {
 			t.Fatalf("Run with bad file expected to fail")
 		}
 	})
@@ -155,7 +161,7 @@ func TestRunPrint(t *testing.T) {
 	opts.Print = true
 
 	withScriptsInPath(t, func() {
-		if err := runWithOptions(opts); err != nil {
+		if err := runWithOptions(opts, nil); err != nil {
 			t.Fatalf("Run with Print failed: %v", err)
 		}
 		// TODO(prashantv): Verify that output is printed to stdout.


### PR DESCRIPTION
pprof is usually run with either:

```
go tool pprof [binary-name] [binary-file]
```

or

```
go tool pprof [url]
```

This change makes it so `go tool pprof` can be replaced with `go-torch`
and it just works. We support `--seconds` as well as `--time` (for backwards compatibility).
