### PR TITLE
Improve help + flags, update README

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: b242f7d839e91092957e62d5debf0d1217aa491911cc064a022d142640ec346f
-updated: 2016-03-28T18:27:44.307463068-07:00
+updated: 2016-06-02T22:55:54.40038441-07:00
 imports:
 - name: github.com/fatih/color
   version: 533cd7fd8a85905f67a1753afb4deddc85ea174f
@@ -12,7 +12,7 @@ imports:
   version: 56b76bdf51f7708750eac80fa38b952bb9f32639
   repo: https://github.com/mattn/go-isatty
 - name: github.com/stretchr/testify
-  version: 6fe211e493929a8aac0469b93f28b1d0688a9a3a
+  version: 8d64eb7173c7753d6419fd4a9caf057398611364
 - name: golang.org/x/sys
   version: 320cb01ddbbf0473674c2585f9b6e245721de355
   subpackages:

--- a/main_test.go
+++ b/main_test.go
@@ -101,7 +101,7 @@ func TestInvalidOptions(t *testing.T) {
 
 func TestRunRaw(t *testing.T) {
 	opts := getDefaultOptions()
-	opts.Raw = true
+	opts.OutputOpts.Raw = true
 
 	if err := runWithOptions(opts, nil); err != nil {
 		t.Fatalf("Run with Raw failed: %v", err)
@@ -120,14 +120,14 @@ func getTempFilename(t *testing.T, suffix string) string {
 
 func TestRunFile(t *testing.T) {
 	opts := getDefaultOptions()
-	opts.File = getTempFilename(t, ".svg")
+	opts.OutputOpts.File = getTempFilename(t, ".svg")
 
 	withScriptsInPath(t, func() {
 		if err := runWithOptions(opts, nil); err != nil {
 			t.Fatalf("Run with Print failed: %v", err)
 		}
 
-		f, err := os.Open(opts.File)
+		f, err := os.Open(opts.OutputOpts.File)
 		if err != nil {
 			t.Errorf("Failed to open output file: %v", err)
 		}
@@ -147,7 +147,7 @@ func TestRunFile(t *testing.T) {
 
 func TestRunBadFile(t *testing.T) {
 	opts := getDefaultOptions()
-	opts.File = "/dev/zero/invalid/file"
+	opts.OutputOpts.File = "/dev/zero/invalid/file"
 
 	withScriptsInPath(t, func() {
 		if err := runWithOptions(opts, nil); err == nil {
@@ -158,7 +158,7 @@ func TestRunBadFile(t *testing.T) {
 
 func TestRunPrint(t *testing.T) {
 	opts := getDefaultOptions()
-	opts.Print = true
+	opts.OutputOpts.Print = true
 
 	withScriptsInPath(t, func() {
 		if err := runWithOptions(opts, nil); err != nil {

--- a/torchlog/torchlog.go
+++ b/torchlog/torchlog.go
@@ -41,7 +41,7 @@ func init() {
 func getPrefix(level string, color *color.Color) string {
 	currentTime := time.Now().Format("15:04:05")
 	toColoredString := color.SprintFunc()
-	return toColoredString(fmt.Sprintf("%s[%s]", level, currentTime))
+	return toColoredString(fmt.Sprintf("%s[%s] ", level, currentTime))
 }
 
 // Fatalf wraps log.Fatalf and adds the current time and color.


### PR DESCRIPTION
Flags now pass through unknown flags (like `--alloc_objects`) to `go tool pprof`, and are broken into multiple sections.

Restructure the README into:
- Usage
- Integration
- Installation
- Development

Can see the rendered output here:
https://github.com/uber/go-torch/blob/readme/README.md

Focus examples on more common usage, and remove less frequently used examples like outputting an SVG to stdout or outputting the raw flamegraph input.
