### PR TITLE
Fix pprof parsing when there's more than 2 columns

### DIFF
--- a/pprof/parser.go
+++ b/pprof/parser.go
@@ -198,7 +198,7 @@ func (p *rawParser) addSample(line string) {
 	funcIDs := p.parseFuncIDs(lineParts[1])
 
 	if len(samples) != len(p.columns) {
-		p.setError(fmt.Errorf("line has more samples (%v) than columns (%v): %v",
+		p.setError(fmt.Errorf("line has a different sample count (%v) than columns (%v): %v",
 			len(samples), len(p.columns), line))
 		return
 	}

--- a/pprof/parser_test.go
+++ b/pprof/parser_test.go
@@ -50,6 +50,7 @@ func parseTest1(t *testing.T) ([]byte, *rawParser) {
 
 func TestParseMemProfile(t *testing.T) {
 	parseTestRawData(t, "testdata/pprof3.raw.txt")
+	parseTestRawData(t, "testdata/pprof-memprofile-1.8.raw.txt")
 }
 
 func TestParse(t *testing.T) {
@@ -62,9 +63,18 @@ func TestParse(t *testing.T) {
 			len(parser.records), expectedNumRecords)
 	}
 	expectedRecords := map[int]*stackRecord{
-		0:  &stackRecord{1, 10000000, []funcID{1, 2, 2, 2, 3, 3, 2, 2, 3, 3, 2, 2, 2, 3, 3, 3, 2, 3, 2, 3, 2, 2, 3, 2, 2, 3, 4, 5, 6}},
-		18: &stackRecord{1, 10000000, []funcID{14, 2, 2, 3, 2, 2, 3, 2, 2, 3, 3, 3, 2, 2, 2, 3, 3, 2, 3, 3, 3, 3, 3, 2, 4, 5, 6}},
-		45: &stackRecord{12, 120000000, []funcID{23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34}},
+		0: &stackRecord{
+			samples: []int64{1, 10000000},
+			stack:   []funcID{1, 2, 2, 2, 3, 3, 2, 2, 3, 3, 2, 2, 2, 3, 3, 3, 2, 3, 2, 3, 2, 2, 3, 2, 2, 3, 4, 5, 6},
+		},
+		18: &stackRecord{
+			samples: []int64{1, 10000000},
+			stack:   []funcID{14, 2, 2, 3, 2, 2, 3, 2, 2, 3, 3, 3, 2, 2, 2, 3, 3, 2, 3, 3, 3, 3, 3, 2, 4, 5, 6},
+		},
+		45: &stackRecord{
+			samples: []int64{12, 120000000},
+			stack:   []funcID{23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34},
+		},
 	}
 	for recordNum, expected := range expectedRecords {
 		if got := parser.records[recordNum]; !reflect.DeepEqual(got, expected) {

--- a/pprof/testdata/pprof-memprofile-1.8.raw.txt
+++ b/pprof/testdata/pprof-memprofile-1.8.raw.txt
@@ -1,0 +1,242 @@
+PeriodType: space bytes
+Period: 524288
+Time: 2017-01-11 15:19:52.794622795 -0800 PST
+Samples:
+alloc_objects/count alloc_space/bytes inuse_objects/count inuse_space/bytes
+        372     524992          0          0: 1 2 3 4 5 6 7 8 9 10 11 
+        372     524992          0          0: 1 2 12 13 14 6 7 8 9 10 11 
+      10923     524312          0          0: 15 16 4 5 6 7 8 9 10 11 
+    2982024  143137176          0          0: 17 18 19 20 21 22 23 24 25 26 27 28 29 30 6 7 8 9 10 11 
+       1491    2099969          0          0: 1 2 3 31 6 7 8 9 10 11 
+    2490387   19923096          0          0: 32 33 34 25 26 27 28 29 30 6 7 8 9 10 11 
+       3587    3673601          0          0: 35 16 4 5 6 7 8 9 10 11 
+    2834605  181414720          0          0: 36 9 10 11 
+    2916441   93326112          0          0: 37 38 39 40 41 20 21 22 23 24 25 26 27 28 29 30 6 7 8 9 10 11 
+    3178787  305163552          0          0: 42 43 20 21 22 23 24 25 26 27 28 29 30 6 7 8 9 10 11 
+    3113435  498149603          0          0: 44 45 46 47 43 20 21 22 23 24 25 26 27 28 29 30 6 7 8 9 10 11 
+    3006223  529095388          0          0: 48 27 28 29 30 6 7 8 9 10 11 
+      10923     524312          0          0: 15 16 49 50 6 7 51 9 10 11 
+        512     524800          0          0: 35 16 49 50 6 7 51 9 10 11 
+      10923     524312          0          0: 15 16 4 5 6 7 51 9 10 11 
+        372     524992          0          0: 1 2 3 31 6 7 51 9 10 11 
+       3075    3148801          0          0: 35 16 4 5 6 7 51 9 10 11 
+    2875129  506022844          0          0: 48 27 28 29 30 6 7 51 9 10 11 
+    2957492  189279520          0          0: 52 9 10 11 
+    2805368  448859011          0          0: 53 9 10 11 
+    3014679   24117432          0          0: 32 33 34 25 26 27 28 29 30 6 7 51 9 10 11 
+    2883672   92277504          0          0: 54 55 9 10 11 
+    3029635  436267522          0          0: 44 45 56 57 58 59 60 24 25 26 27 28 29 30 6 7 51 9 10 11 
+      10923     524312          0          0: 15 16 4 5 6 7 61 9 10 11 
+        745    1049984          0          0: 1 2 3 4 5 6 7 61 9 10 11 
+        372     524992          0          0: 1 2 3 31 6 7 61 9 10 11 
+       8192     524320          0          0: 62 16 31 6 7 61 9 10 11 
+    4390945   35127564          0          0: 32 33 34 25 26 27 28 29 30 6 7 61 9 10 11 
+       1537    1574400          0          0: 35 16 4 5 6 7 61 9 10 11 
+    3956977  253246560          0          0: 63 9 10 11 
+    3915895  125308656          0          0: 54 64 9 10 11 
+    3843437  676445046          0          0: 48 27 28 29 30 6 7 61 9 10 11 
+    4043879  323510376          0          0: 65 9 10 11 
+    6078835  389045440          0          0: 66 9 10 11 
+        372     524992          0          0: 1 2 12 13 67 68 9 10 11 
+      65540    4194560          0          0: 69 9 10 11 
+        372     524992          0          0: 1 2 3 31 6 7 70 9 10 11 
+     109675  112307235          0          0: 71 72 73 74 68 9 10 11 
+    5898600  377510400          0          0: 75 9 10 11 
+        372     524992          0          0: 1 2 3 49 50 6 7 76 9 10 11 
+       8192     524320          0          0: 62 16 31 6 7 76 9 10 11 
+       1025    1049600          0          0: 35 16 49 50 6 7 76 9 10 11 
+    5865830  375413120          0          0: 77 9 10 11 
+        372     524992          0          0: 1 2 3 49 50 6 7 78 9 10 11 
+        372     524992          0          0: 1 2 3 31 6 7 78 9 10 11 
+    6316417  404250720          0          0: 79 9 10 11 
+        512     524800          0          0: 35 16 4 5 6 7 80 9 10 11 
+    1540119   24641912          0          0: 81 82 9 10 11 
+    6005102  384326560          0          0: 83 9 10 11 
+        372     524992          0          0: 1 2 3 49 50 6 7 84 9 10 11 
+      10923     524312          0          0: 15 16 49 50 6 7 84 9 10 11 
+        372     524992          0          0: 1 2 3 31 6 7 84 9 10 11 
+    6062450  387996800          0          0: 85 9 10 11 
+       1025    1049600          0          0: 35 16 49 50 6 7 86 9 10 11 
+   11100837  710453600          0          0: 87 9 10 11 
+       8192     524320          0          0: 62 16 31 6 7 88 9 10 11 
+      10923     524312          0          0: 15 16 4 5 6 7 88 9 10 11 
+        512     524800          0          0: 35 16 4 5 6 7 88 9 10 11 
+   11117222  711502240          0          0: 89 9 10 11 
+       1025    1049600          0          0: 35 16 4 5 6 7 90 9 10 11 
+    5914985  378559040          0          0: 91 9 10 11 
+        372     524992          0          0: 1 2 3 49 50 6 7 92 9 10 11 
+       8192     524320          0          0: 62 16 31 6 7 92 9 10 11 
+       1537    1574400          0          0: 35 16 4 5 6 7 92 9 10 11 
+        372     524992          0          0: 1 2 3 31 6 7 92 9 10 11 
+       1260     524496       1260     524496: 93 94 95 96 97 98 99 100 
+   11322035  724610240          0          0: 101 9 10 11 
+        512     524800          0          0: 35 16 49 50 6 7 92 9 10 11 
+      10923     524312          0          0: 102 103 104 105 106 11 
+        128     526338          0          0: 107 108 11 
+       4681     524344          0          0: 109 110 111 112 113 114 115 116 117 118 119 120 121 122 11 
+       3277     524368          0          0: 109 110 111 112 113 114 115 116 117 118 119 120 121 122 11 
+      65537    1048592          0          0: 71 72 123 124 110 111 112 113 114 115 116 117 118 119 120 121 122 11 
+       4096     524352          0          0: 109 110 111 112 113 114 115 116 117 118 119 120 121 122 11 
+      32769    1048608          0          0: 125 119 120 121 122 11 
+      16385    1048640          0          0: 71 72 126 111 112 113 114 115 116 117 118 119 120 121 122 11 
+      98305    1572888          0          0: 54 127 128 129 130 131 132 121 122 11 
+      14044    1573032          0          0: 133 134 116 117 118 119 120 121 122 11 
+       7283    2097728          0          0: 135 115 116 117 118 119 120 121 122 11 
+      65537    1048592          0          0: 37 136 137 130 131 132 121 122 11 
+       8192     524320          0          0: 138 128 129 130 131 132 121 122 11 
+       4096     524352          0          0: 71 72 126 111 112 113 114 115 117 118 119 120 139 122 11 
+       3641     524360          0          0: 71 140 141 130 131 132 139 122 11 
+       2979     524376          0          0: 71 72 126 111 112 113 114 115 117 118 119 120 139 122 11 
+       3641     524360          0          0: 142 130 131 132 139 122 11 
+      32768     524296          0          0: 37 136 137 130 131 132 139 122 11 
+       3641    1048864          0          0: 135 115 117 118 119 120 139 122 11 
+       3277     524368          0          0: 71 140 141 130 131 132 139 122 11 
+      10923     524312          0          0: 71 140 141 130 131 132 139 122 11 
+       2731     524384          0          0: 133 134 117 118 119 120 139 122 11 
+      16384     524304          0          0: 143 122 11 
+Locations
+     1: 0x105ff4a M=1 sync.(*Pool).pinSlow /Users/prashant/go.versions/go1.8b2/src/sync/pool.go:205 s=0
+     2: 0x105fe2c M=1 sync.(*Pool).pin /Users/prashant/go.versions/go1.8b2/src/sync/pool.go:184 s=0
+     3: 0x105fabf M=1 sync.(*Pool).Get /Users/prashant/go.versions/go1.8b2/src/sync/pool.go:121 s=0
+     4: 0x1304bb3 M=1 github.com/uber-go/zap.(*jsonEncoder).WriteEntry /Users/prashant/gocode/src/github.com/uber-go/zap/json_encoder.go:202 s=0
+     5: 0x130856a M=1 github.com/uber-go/zap.Meta.Encode /Users/prashant/gocode/src/github.com/uber-go/zap/meta.go:118 s=0
+     6: 0x1307acf M=1 github.com/uber-go/zap.(*logger).log /Users/prashant/gocode/src/github.com/uber-go/zap/logger.go:130 s=0
+     7: 0x13075d5 M=1 github.com/uber-go/zap.(*logger).Info /Users/prashant/gocode/src/github.com/uber-go/zap/logger.go:97 s=0
+     8: 0x134693e M=1 github.com/uber-go/zap_test.BenchmarkObjectField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:153 s=0
+     9: 0x1344ecc M=1 github.com/uber-go/zap_test.withBenchedLogger.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:59 s=0
+    10: 0x10dfa92 M=1 testing.(*B).RunParallel.func1 /Users/prashant/go.versions/go1.8b2/src/testing/benchmark.go:603 s=0
+    11: 0x10597a1 M=1 runtime.goexit /Users/prashant/go.versions/go1.8b2/src/runtime/asm_amd64.s:2185 s=0
+    12: 0x105f8cd M=1 sync.(*Pool).Put /Users/prashant/go.versions/go1.8b2/src/sync/pool.go:93 s=0
+    13: 0x1303b53 M=1 github.com/uber-go/zap.(*jsonEncoder).Free /Users/prashant/gocode/src/github.com/uber-go/zap/json_encoder.go:96 s=0
+    14: 0x130859e M=1 github.com/uber-go/zap.Meta.Encode /Users/prashant/gocode/src/github.com/uber-go/zap/meta.go:120 s=0
+    15: 0x13255b1 M=1 github.com/uber-go/zap.glob..func2 /Users/prashant/gocode/src/github.com/uber-go/zap/json_encoder.go:54 s=0
+    16: 0x105fb3d M=1 sync.(*Pool).Get /Users/prashant/go.versions/go1.8b2/src/sync/pool.go:144 s=0
+    17: 0x1075c91 M=1 time.Time.MarshalJSON /Users/prashant/go.versions/go1.8b2/src/time/time.go:956 s=0
+    18: 0x107c79d M=1 time.(*Time).MarshalJSON <autogenerated>:35 s=0
+    19: 0x11444cf M=1 encoding/json.marshalerEncoder /Users/prashant/go.versions/go1.8b2/src/encoding/json/encode.go:451 s=0
+    20: 0x1145ea3 M=1 encoding/json.(*structEncoder).encode /Users/prashant/go.versions/go1.8b2/src/encoding/json/encode.go:637 s=0
+    21: 0x1151844 M=1 encoding/json.(*structEncoder).(encoding/json.encode)-fm /Users/prashant/go.versions/go1.8b2/src/encoding/json/encode.go:659 s=0
+    22: 0x11473d3 M=1 encoding/json.(*ptrEncoder).encode /Users/prashant/go.versions/go1.8b2/src/encoding/json/encode.go:787 s=0
+    23: 0x1151a44 M=1 encoding/json.(*ptrEncoder).(encoding/json.encode)-fm /Users/prashant/go.versions/go1.8b2/src/encoding/json/encode.go:791 s=0
+    24: 0x1143a82 M=1 encoding/json.(*encodeState).reflectValue /Users/prashant/go.versions/go1.8b2/src/encoding/json/encode.go:324 s=0
+    25: 0x1143768 M=1 encoding/json.(*encodeState).marshal /Users/prashant/go.versions/go1.8b2/src/encoding/json/encode.go:297 s=0
+    26: 0x114331e M=1 encoding/json.Marshal /Users/prashant/go.versions/go1.8b2/src/encoding/json/encode.go:161 s=0
+    27: 0x13047bf M=1 github.com/uber-go/zap.(*jsonEncoder).AddObject /Users/prashant/gocode/src/github.com/uber-go/zap/json_encoder.go:173 s=0
+    28: 0x1303044 M=1 github.com/uber-go/zap.Field.AddTo /Users/prashant/gocode/src/github.com/uber-go/zap/field.go:218 s=0
+    29: 0x13032ee M=1 github.com/uber-go/zap.addFields /Users/prashant/gocode/src/github.com/uber-go/zap/field.go:240 s=0
+    30: 0x13082fc M=1 github.com/uber-go/zap.Meta.Encode /Users/prashant/gocode/src/github.com/uber-go/zap/meta.go:104 s=0
+    31: 0x130831d M=1 github.com/uber-go/zap.Meta.Encode /Users/prashant/gocode/src/github.com/uber-go/zap/meta.go:105 s=0
+    32: 0x1143b74 M=1 encoding/json.typeEncoder /Users/prashant/go.versions/go1.8b2/src/encoding/json/encode.go:349 s=0
+    33: 0x1143afc M=1 encoding/json.valueEncoder /Users/prashant/go.versions/go1.8b2/src/encoding/json/encode.go:344 s=0
+    34: 0x1143a3f M=1 encoding/json.(*encodeState).reflectValue /Users/prashant/go.versions/go1.8b2/src/encoding/json/encode.go:323 s=0
+    35: 0x1325583 M=1 github.com/uber-go/zap.glob..func2 /Users/prashant/gocode/src/github.com/uber-go/zap/json_encoder.go:54 s=0
+    36: 0x13468aa M=1 github.com/uber-go/zap_test.BenchmarkObjectField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:152 s=0
+    37: 0x1011a7b M=1 reflect.unsafe_New /Users/prashant/go.versions/go1.8b2/src/runtime/malloc.go:806 s=0
+    38: 0x109c8ed M=1 reflect.packEface /Users/prashant/go.versions/go1.8b2/src/reflect/value.go:111 s=0
+    39: 0x10a0584 M=1 reflect.valueInterface /Users/prashant/go.versions/go1.8b2/src/reflect/value.go:941 s=0
+    40: 0x10a0464 M=1 reflect.Value.Interface /Users/prashant/go.versions/go1.8b2/src/reflect/value.go:911 s=0
+    41: 0x114448a M=1 encoding/json.marshalerEncoder /Users/prashant/go.versions/go1.8b2/src/encoding/json/encode.go:446 s=0
+    42: 0x114acae M=1 encoding/json.compact /Users/prashant/go.versions/go1.8b2/src/encoding/json/indent.go:16 s=0
+    43: 0x1144622 M=1 encoding/json.marshalerEncoder /Users/prashant/go.versions/go1.8b2/src/encoding/json/encode.go:454 s=0
+    44: 0x10cb7c7 M=1 bytes.makeSlice /Users/prashant/go.versions/go1.8b2/src/bytes/buffer.go:201 s=0
+    45: 0x10cb0e7 M=1 bytes.(*Buffer).grow /Users/prashant/go.versions/go1.8b2/src/bytes/buffer.go:109 s=0
+    46: 0x10cb2e1 M=1 bytes.(*Buffer).Write /Users/prashant/go.versions/go1.8b2/src/bytes/buffer.go:137 s=0
+    47: 0x114b0be M=1 encoding/json.compact /Users/prashant/go.versions/go1.8b2/src/encoding/json/indent.go:57 s=0
+    48: 0x11432e1 M=1 encoding/json.Marshal /Users/prashant/go.versions/go1.8b2/src/encoding/json/encode.go:160 s=0
+    49: 0x1304971 M=1 github.com/uber-go/zap.(*jsonEncoder).Clone /Users/prashant/gocode/src/github.com/uber-go/zap/json_encoder.go:184 s=0
+    50: 0x1308289 M=1 github.com/uber-go/zap.Meta.Encode /Users/prashant/gocode/src/github.com/uber-go/zap/meta.go:102 s=0
+    51: 0x134675d M=1 github.com/uber-go/zap_test.BenchmarkStringsField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:147 s=0
+    52: 0x13466c3 M=1 github.com/uber-go/zap_test.BenchmarkStringsField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:146 s=0
+    53: 0x13465b2 M=1 github.com/uber-go/zap_test.BenchmarkStringsField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:146 s=0
+    54: 0x100efc8 M=1 runtime.convT2E /Users/prashant/go.versions/go1.8b2/src/runtime/iface.go:198 s=0
+    55: 0x134661c M=1 github.com/uber-go/zap_test.BenchmarkStringsField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:146 s=0
+    56: 0x10cba0c M=1 bytes.(*Buffer).WriteByte /Users/prashant/go.versions/go1.8b2/src/bytes/buffer.go:238 s=0
+    57: 0x11471c1 M=1 encoding/json.(*arrayEncoder).encode /Users/prashant/go.versions/go1.8b2/src/encoding/json/encode.go:763 s=0
+    58: 0x11519c4 M=1 encoding/json.(*arrayEncoder).(encoding/json.encode)-fm /Users/prashant/go.versions/go1.8b2/src/encoding/json/encode.go:774 s=0
+    59: 0x1146e61 M=1 encoding/json.(*sliceEncoder).encode /Users/prashant/go.versions/go1.8b2/src/encoding/json/encode.go:742 s=0
+    60: 0x1151944 M=1 encoding/json.(*sliceEncoder).(encoding/json.encode)-fm /Users/prashant/go.versions/go1.8b2/src/encoding/json/encode.go:753 s=0
+    61: 0x134651f M=1 github.com/uber-go/zap_test.BenchmarkIntsField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:141 s=0
+    62: 0x132564d M=1 github.com/uber-go/zap.glob..func3 /Users/prashant/gocode/src/github.com/uber-go/zap/meta.go:33 s=0
+    63: 0x1346485 M=1 github.com/uber-go/zap_test.BenchmarkIntsField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:140 s=0
+    64: 0x13463de M=1 github.com/uber-go/zap_test.BenchmarkIntsField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:140 s=0
+    65: 0x1346382 M=1 github.com/uber-go/zap_test.BenchmarkIntsField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:140 s=0
+    66: 0x1346266 M=1 github.com/uber-go/zap_test.BenchmarkMarshalerField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:134 s=0
+    67: 0x1302905 M=1 github.com/uber-go/zap.Stack /Users/prashant/gocode/src/github.com/uber-go/zap/field.go:146 s=0
+    68: 0x1346094 M=1 github.com/uber-go/zap_test.BenchmarkStackField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:128 s=0
+    69: 0x13460bf M=1 github.com/uber-go/zap_test.BenchmarkStackField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:128 s=0
+    70: 0x1346138 M=1 github.com/uber-go/zap_test.BenchmarkStackField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:129 s=0
+    71: 0x1045818 M=1 runtime.rawstringtmp /Users/prashant/go.versions/go1.8b2/src/runtime/string.go:107 s=0
+    72: 0x104570e M=1 runtime.slicebytetostring /Users/prashant/go.versions/go1.8b2/src/runtime/string.go:89 s=0
+    73: 0x1308d2e M=1 github.com/uber-go/zap.takeStacktrace /Users/prashant/gocode/src/github.com/uber-go/zap/stacktrace.go:41 s=0
+    74: 0x1302843 M=1 github.com/uber-go/zap.Stack /Users/prashant/gocode/src/github.com/uber-go/zap/field.go:155 s=0
+    75: 0x1345ef9 M=1 github.com/uber-go/zap_test.BenchmarkErrorField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:122 s=0
+    76: 0x1345dcd M=1 github.com/uber-go/zap_test.BenchmarkDurationField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:116 s=0
+    77: 0x1345d33 M=1 github.com/uber-go/zap_test.BenchmarkDurationField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:115 s=0
+    78: 0x1345bc3 M=1 github.com/uber-go/zap_test.BenchmarkTimeField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:110 s=0
+    79: 0x1345b29 M=1 github.com/uber-go/zap_test.BenchmarkTimeField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:109 s=0
+    80: 0x134596e M=1 github.com/uber-go/zap_test.BenchmarkStringerField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:103 s=0
+    81: 0x100f081 M=1 runtime.convT2I /Users/prashant/go.versions/go1.8b2/src/runtime/iface.go:219 s=0
+    82: 0x1345824 M=1 github.com/uber-go/zap_test.BenchmarkStringerField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:102 s=0
+    83: 0x13458d4 M=1 github.com/uber-go/zap_test.BenchmarkStringerField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:102 s=0
+    84: 0x134578b M=1 github.com/uber-go/zap_test.BenchmarkStringField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:97 s=0
+    85: 0x13456f7 M=1 github.com/uber-go/zap_test.BenchmarkStringField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:96 s=0
+    86: 0x13455dc M=1 github.com/uber-go/zap_test.BenchmarkInt64Field.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:91 s=0
+    87: 0x1345548 M=1 github.com/uber-go/zap_test.BenchmarkInt64Field.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:90 s=0
+    88: 0x134543c M=1 github.com/uber-go/zap_test.BenchmarkIntField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:85 s=0
+    89: 0x13453a8 M=1 github.com/uber-go/zap_test.BenchmarkIntField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:84 s=0
+    90: 0x1345294 M=1 github.com/uber-go/zap_test.BenchmarkFloat64Field.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:79 s=0
+    91: 0x13451fa M=1 github.com/uber-go/zap_test.BenchmarkFloat64Field.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:78 s=0
+    92: 0x13450dc M=1 github.com/uber-go/zap_test.BenchmarkBoolField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:73 s=0
+    93: 0x1034a71 M=1 runtime.malg /Users/prashant/go.versions/go1.8b2/src/runtime/proc.go:2791 s=0
+    94: 0x1029be9 M=1 runtime.mpreinit /Users/prashant/go.versions/go1.8b2/src/runtime/os_darwin.go:172 s=0
+    95: 0x102f24c M=1 runtime.mcommoninit /Users/prashant/go.versions/go1.8b2/src/runtime/proc.go:531 s=0
+    96: 0x1030f29 M=1 runtime.allocm /Users/prashant/go.versions/go1.8b2/src/runtime/proc.go:1315 s=0
+    97: 0x10316a9 M=1 runtime.newm /Users/prashant/go.versions/go1.8b2/src/runtime/proc.go:1581 s=0
+    98: 0x1030736 M=1 runtime.startTheWorldWithSema /Users/prashant/go.versions/go1.8b2/src/runtime/proc.go:1094 s=0
+    99: 0x1056c69 M=1 runtime.systemstack /Users/prashant/go.versions/go1.8b2/src/runtime/asm_amd64.s:318 s=0
+   100: 0x10307b0 M=1 runtime.mstart /Users/prashant/go.versions/go1.8b2/src/runtime/proc.go:1102 s=0
+   101: 0x1345048 M=1 github.com/uber-go/zap_test.BenchmarkBoolField.func1 /Users/prashant/gocode/src/github.com/uber-go/zap/logger_bench_test.go:72 s=0
+   102: 0x121a842 M=1 container/list.(*List).PushFront /Users/prashant/go.versions/go1.8b2/src/container/list/list.go:133 s=0
+   103: 0x12d70f4 M=1 net/http.(*connLRU).add /Users/prashant/go.versions/go1.8b2/src/net/http/transport.go:2145 s=0
+   104: 0x12cd89b M=1 net/http.(*Transport).tryPutIdleConn /Users/prashant/go.versions/go1.8b2/src/net/http/transport.go:702 s=0
+   105: 0x12db7c0 M=1 net/http.(*persistConn).readLoop.func2 /Users/prashant/go.versions/go1.8b2/src/net/http/transport.go:1447 s=0
+   106: 0x12d3ec7 M=1 net/http.(*persistConn).readLoop /Users/prashant/go.versions/go1.8b2/src/net/http/transport.go:1606 s=0
+   107: 0x12d0bbb M=1 net/http.(*Transport).dialConn /Users/prashant/go.versions/go1.8b2/src/net/http/transport.go:1115 s=0
+   108: 0x12db4d8 M=1 net/http.(*Transport).getConn.func4 /Users/prashant/go.versions/go1.8b2/src/net/http/transport.go:908 s=0
+   109: 0x1142a47 M=1 encoding/json.unquoteBytes /Users/prashant/go.versions/go1.8b2/src/encoding/json/decode.go:1187 s=0
+   110: 0x11411e6 M=1 encoding/json.(*decodeState).literalStore /Users/prashant/go.versions/go1.8b2/src/encoding/json/decode.go:912 s=0
+   111: 0x113f1bd M=1 encoding/json.(*decodeState).literal /Users/prashant/go.versions/go1.8b2/src/encoding/json/decode.go:800 s=0
+   112: 0x113c03e M=1 encoding/json.(*decodeState).value /Users/prashant/go.versions/go1.8b2/src/encoding/json/decode.go:407 s=0
+   113: 0x113b47a M=1 encoding/json.(*decodeState).unmarshal /Users/prashant/go.versions/go1.8b2/src/encoding/json/decode.go:185 s=0
+   114: 0x113ae38 M=1 encoding/json.Unmarshal /Users/prashant/go.versions/go1.8b2/src/encoding/json/decode.go:104 s=0
+   115: 0x13162c3 M=1 github.com/uber-go/zap.roundTrip /Users/prashant/gocode/src/github.com/uber-go/zap/json_encoder_quick_test.go:49 s=0
+   116: 0x13164c5 M=1 github.com/uber-go/zap.roundTripASCII /Users/prashant/gocode/src/github.com/uber-go/zap/json_encoder_quick_test.go:68 s=0
+   117: 0x1057008 M=1 runtime.call32 /Users/prashant/go.versions/go1.8b2/src/runtime/asm_amd64.s:501 s=0
+   118: 0x109de3f M=1 reflect.Value.call /Users/prashant/go.versions/go1.8b2/src/reflect/value.go:437 s=0
+   119: 0x109d404 M=1 reflect.Value.Call /Users/prashant/go.versions/go1.8b2/src/reflect/value.go:302 s=0
+   120: 0x12ffd8d M=1 testing/quick.Check /Users/prashant/go.versions/go1.8b2/src/testing/quick/quick.go:285 s=0
+   121: 0x13165d2 M=1 github.com/uber-go/zap.TestJSONQuick /Users/prashant/gocode/src/github.com/uber-go/zap/json_encoder_quick_test.go:79 s=0
+   122: 0x10dd233 M=1 testing.tRunner /Users/prashant/go.versions/go1.8b2/src/testing/testing.go:657 s=0
+   123: 0x11427eb M=1 encoding/json.getu4 /Users/prashant/go.versions/go1.8b2/src/encoding/json/decode.go:1143 s=0
+   124: 0x1142cbf M=1 encoding/json.unquoteBytes /Users/prashant/go.versions/go1.8b2/src/encoding/json/decode.go:1233 s=0
+   125: 0x109de9c M=1 reflect.Value.call /Users/prashant/go.versions/go1.8b2/src/reflect/value.go:453 s=0
+   126: 0x1141259 M=1 encoding/json.(*decodeState).literalStore /Users/prashant/go.versions/go1.8b2/src/encoding/json/decode.go:936 s=0
+   127: 0x131642e M=1 github.com/uber-go/zap.ASCII.Generate /Users/prashant/gocode/src/github.com/uber-go/zap/json_encoder_quick_test.go:64 s=0
+   128: 0x13369fa M=1 github.com/uber-go/zap.(*ASCII).Generate <autogenerated>:126 s=0
+   129: 0x12ff80c M=1 testing/quick.sizedValue /Users/prashant/go.versions/go1.8b2/src/testing/quick/quick.go:65 s=0
+   130: 0x12fe3e8 M=1 testing/quick.Value /Users/prashant/go.versions/go1.8b2/src/testing/quick/quick.go:57 s=0
+   131: 0x1300113 M=1 testing/quick.arbitraryValues /Users/prashant/go.versions/go1.8b2/src/testing/quick/quick.go:346 s=0
+   132: 0x12ffd31 M=1 testing/quick.Check /Users/prashant/go.versions/go1.8b2/src/testing/quick/quick.go:280 s=0
+   133: 0x1316049 M=1 github.com/uber-go/zap.encodeString /Users/prashant/gocode/src/github.com/uber-go/zap/json_encoder_quick_test.go:37 s=0
+   134: 0x1316249 M=1 github.com/uber-go/zap.roundTrip /Users/prashant/gocode/src/github.com/uber-go/zap/json_encoder_quick_test.go:46 s=0
+   135: 0x113ad21 M=1 encoding/json.Unmarshal /Users/prashant/go.versions/go1.8b2/src/encoding/json/decode.go:97 s=0
+   136: 0x10a4866 M=1 reflect.Zero /Users/prashant/go.versions/go1.8b2/src/reflect/value.go:2113 s=0
+   137: 0x12fe480 M=1 testing/quick.sizedValue /Users/prashant/go.versions/go1.8b2/src/testing/quick/quick.go:64 s=0
+   138: 0x1316373 M=1 github.com/uber-go/zap.ASCII.Generate /Users/prashant/gocode/src/github.com/uber-go/zap/json_encoder_quick_test.go:59 s=0
+   139: 0x131656d M=1 github.com/uber-go/zap.TestJSONQuick /Users/prashant/gocode/src/github.com/uber-go/zap/json_encoder_quick_test.go:73 s=0
+   140: 0x1045bb6 M=1 runtime.slicerunetostring /Users/prashant/go.versions/go1.8b2/src/runtime/string.go:189 s=0
+   141: 0x12fefc9 M=1 testing/quick.sizedValue /Users/prashant/go.versions/go1.8b2/src/testing/quick/quick.go:149 s=0
+   142: 0x12fef05 M=1 testing/quick.sizedValue /Users/prashant/go.versions/go1.8b2/src/testing/quick/quick.go:145 s=0
+   143: 0x1315076 M=1 github.com/uber-go/zap.TestHooksNilEntry /Users/prashant/gocode/src/github.com/uber-go/zap/hook_test.go:81 s=0
+Mappings
+1: 0x0/0x0/0x0 zap.test  [FN][FL][LN][IN]


### PR DESCRIPTION
Previously, the pprof parser assumed there were 2 columns, and stored
them as "samples" and "total". Instead parse all values and store
columns which we can use in future.

Fixes #51 but I noticed a new issue with how we select the sample to display: #52