### PR TITLE
Improve instructions on fetching flamegraph scripts

### DIFF
--- a/renderer/flamegraph.go
+++ b/renderer/flamegraph.go
@@ -30,7 +30,10 @@ import (
 var errNoPerlScript = errors.New("Cannot find flamegraph scripts in the PATH or current " +
 	"directory. You can download the script at https://github.com/brendangregg/FlameGraph. " +
 	"These scripts should be added to your PATH or in the directory where go-torch is executed. " +
-	"Alternatively, you can run go-torch with the --raw flag.")
+	"Alternatively, you can run go-torch with the --raw flag." +
+	"Once installed you should have `stackcollapse.pl` and `flamegraph.pl`" +
+	"either with or without the `.pl` suffix, in your $PATH.",
+)
 
 var (
 	stackCollapseScripts = []string{"stackcollapse.pl", "./stackcollapse.pl", "./FlameGraph/stackcollapse.pl"}


### PR DESCRIPTION
The first time I set this up on a new machine it pointed me to the repo,
but didn't say which files I needed. So it took some trial and error
before I got it working. We should be explicit in what we use.