### PR TITLE
Fix sample selection to not always use first index

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,28 +1,29 @@
-hash: bed3a075baacc2eac4f2ec779f188ce2be7c9daffd77e4a5cada069b5d1f54f8
-updated: 2016-10-28T14:22:52.238218907-07:00
+hash: e02633304cb0e642a7f236a49dd73b0c5b9bddb3e2b35272191bdc16c6e62baa
+updated: 2017-01-18T09:23:43.933063939-08:00
 imports:
 - name: github.com/fatih/color
-  version: bf82308e8c8546dc2b945157173eb8a959ae9505
+  version: 42c364ba490082e4815b5222728711b3440603eb
 - name: github.com/jessevdk/go-flags
-  version: 4cc2832a6e6d1d3b815e2b9d544b2a4dfb3ce8fa
+  version: 4e64e4a4e2552194cf594243e23aa9baf3b4297e
 - name: github.com/mattn/go-colorable
-  version: 6c903ff4aa50920ca86087a280590b36b3152b9c
+  version: d228849504861217f796da67fae4f6e347643f15
 - name: github.com/mattn/go-isatty
-  version: 66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8
+  version: 30a891c33c7cde7b02a981314b4228ec99380cca
 - name: golang.org/x/sys
-  version: a646d33e2ee3172a661fc09bca23bb4889a41bc8
+  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
   subpackages:
   - unix
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
+  version: 2402e8e7a02fc811447d11f881aa9746cdc57983
   subpackages:
   - assert
+  - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,3 +6,4 @@ testImport:
 - package: github.com/stretchr/testify
   subpackages:
     - assert
+    - require

--- a/main.go
+++ b/main.go
@@ -88,12 +88,13 @@ func runWithOptions(allOpts *options, remaining []string) error {
 		return fmt.Errorf("could not get raw output from pprof: %v", err)
 	}
 
-	callStacks, err := pprof.ParseRaw(pprofRawOutput)
+	profile, err := pprof.ParseRaw(pprofRawOutput)
 	if err != nil {
 		return fmt.Errorf("could not parse raw pprof output: %v", err)
 	}
 
-	flameInput, err := renderer.ToFlameInput(callStacks)
+	sampleIndex := pprof.SelectSample(remaining, profile.SampleNames)
+	flameInput, err := renderer.ToFlameInput(profile, sampleIndex)
 	if err != nil {
 		return fmt.Errorf("could not convert stacks to flamegraph input: %v", err)
 	}

--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -33,7 +33,7 @@ import (
 // Options are parameters for pprof.
 type Options struct {
 	BaseURL     string   `short:"u" long:"url" default:"http://localhost:8080" description:"Base URL of your Go program"`
-	URLSuffix   string   `short:"s" long:"suffix" default:"/debug/pprof/profile" description:"URL path of pprof profile"`
+	URLSuffix   string   `long:"suffix" default:"/debug/pprof/profile" description:"URL path of pprof profile"`
 	BinaryFile  string   `short:"b" long:"binaryinput" description:"File path of previously saved binary profile. (binary profile is anything accepted by https://golang.org/cmd/pprof)"`
 	BinaryName  string   `long:"binaryname" description:"File path of the binary that the binaryinput is for, used for pprof inputs"`
 	TimeSeconds int      `short:"t" long:"seconds" default:"30" description:"Number of seconds to profile for"`

--- a/pprof/select_sample.go
+++ b/pprof/select_sample.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/pprof/select_sample_test.go
+++ b/pprof/select_sample_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pprof
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelectSample(t *testing.T) {
+	names := []string{
+		"samples/count",
+		"cpu/nanoseconds",
+		"alloc_objects/count",
+		"alloc_space/bytes",
+		"inuse_objects/count",
+		"inuse_space/bytes",
+	}
+
+	tests := []struct {
+		args []string
+		want int
+	}{
+		{
+			args: nil,
+			want: 0,
+		},
+		{
+			args: []string{"-sample_index", "5"},
+			want: 5,
+		},
+		{
+			// missing argument for sample_index
+			args: []string{"-sample_index"},
+			want: 0,
+		},
+		{
+			// negative sample index is out of range.
+			args: []string{"-sample_index", "-1"},
+			want: 0,
+		},
+		{
+			// sample index is not a number.
+			args: []string{"-sample_index", "nan"},
+			want: 0,
+		},
+		{
+			// index out of range.
+			args: []string{"-sample_index", "10"},
+			want: 0,
+		},
+		{
+			args: []string{"-unknown", "options"},
+			want: 0,
+		},
+		{
+			args: []string{"-alloc_objects"},
+			want: 2,
+		},
+		{
+			args: []string{"-alloc_space"},
+			want: 3,
+		},
+		{
+			args: []string{"-inuse_objects"},
+			want: 4,
+		},
+		{
+			args: []string{"-inuse_space"},
+			want: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		got := SelectSample(tt.args, names)
+		assert.Equal(t, tt.want, got, "Args: %v", tt.args)
+	}
+
+}

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -28,14 +28,18 @@ import (
 )
 
 func TestToFlameInput(t *testing.T) {
-	samples := []*stack.Sample{
-		{Funcs: []string{"func1", "func2"}, Count: 10},
-		{Funcs: []string{"func3"}, Count: 8},
-		{Funcs: []string{"func4", "func5", "func6"}, Count: 3},
+	profile := &stack.Profile{
+		SampleNames: []string{"samples/count"},
+		Samples: []*stack.Sample{
+			{Funcs: []string{"func1", "func2"}, Counts: []int64{10}},
+			{Funcs: []string{"func3"}, Counts: []int64{8}},
+			{Funcs: []string{"func4", "func5", "func6"}, Counts: []int64{3}},
+		},
 	}
+
 	expected := "func1;func2 10\nfunc3 8\nfunc4;func5;func6 3\n"
 
-	out, err := ToFlameInput(samples)
+	out, err := ToFlameInput(profile, 0)
 	if err != nil {
 		t.Fatalf("ToFlameInput failed: %v", err)
 	}


### PR DESCRIPTION
Currently, go-torch always uses the first sample it finds in the
profile. With 1.8, memory profiles always have inuse/alloc so we
need to select the right sample, otherwise we're always showing
alloc.

This allows allows selection of a custom sample using sample_index
for non-memory profiles.

Fixes #52.