### PR TITLE
Drop all but first line during location parsing

### DIFF
--- a/pprof/parser.go
+++ b/pprof/parser.go
@@ -168,6 +168,10 @@ func (p *rawParser) addLocation(line string) {
 		case len(parts) == 3 && strings.HasPrefix(parts[2], "M="):
 			// Some lines have an ID, a mapping ID and an address, we can
 			// ignore those as well.
+		case len(parts) == 3 && strings.HasPrefix(parts[2], "s="):
+			// See https://github.com/uber/go-torch/issues/63#issuecomment-315658039.
+			// The raw "format" sometimes prints multiple lines per location. We can't
+			// see previous lines here, so for now we just skip them.
 		default:
 			p.setError(fmt.Errorf("malformed location line: %v", line))
 		}

--- a/pprof/parser_test.go
+++ b/pprof/parser_test.go
@@ -122,14 +122,17 @@ func TestParseRawValid(t *testing.T) {
 
 func TestParseLocation(t *testing.T) {
 	contents := `Samples:
-    samples/count cpu/nanoseconds
+samples/count cpu/nanoseconds
     2   10000000: 1 2
-    Locations:
-    1: 0x206f main.fib :0 s=0
-    2: 0x16e1 M=1
-    3: 0x16f4 M=1
-    4: 0x1534 M=1
-    5: 0x207a main.fib :0 s=0
+Locations
+     1: 0x206f main.fib :0 s=0
+     2: 0x16e1 M=1
+     3: 0x16f4 M=1
+     4: 0x1534 M=1
+	 5: 0x207a main.fib :0 s=0
+   730: 0x4021625 runtime.heapBits.next /usr/local/Cellar/go/1.9beta2/libexec/src/runtime/mbitmap.go:464 s=0
+             runtime.scanobject /usr/local/Cellar/go/1.9beta2/libexec/src/runtime/mgcmark.go:1162 s=0
+   731: 0x40473ab runtime.growslice /usr/local/Cellar/go/1.9beta2/libexec/src/runtime/slice.go:140 s=0
     `
 	_, err := ParseRaw([]byte(contents))
 	if err != nil {


### PR DESCRIPTION
This is a fix but not really a good solution for #63. The problem arises
because the raw format (at least in go1.9) can contain lines of the form

```
[...]
   729: 0x4d6a395 github.com/cockroachdb/cockroach/pkg/sql.(*tableState).release /Users/tschottdorf/go/src/github.com/cockroachdb/cockroach/pkg/sql/lease.go:791 s=0
   730: 0x4021625 runtime.heapBits.next /usr/local/Cellar/go/1.9beta2/libexec/src/runtime/mbitmap.go:464 s=0
             runtime.scanobject /usr/local/Cellar/go/1.9beta2/libexec/src/runtime/mgcmark.go:1162 s=0
[...]
```

and the last line is not parsed correctly. The way parsing is set up is
line-by-line, so it's not straightforward to recover. Instead of a bigger
refactor to try to address this, this change just drops these extra lines,
and we should really implement #64.

Note also that I changed some lines in the parsing test to match what is
actually produced by go1.9 -- I'm not sure if the previous snippet was
simply not true-to-original or whether perhaps the raw format has changed.
Either way, using the raw format seems to invite regular breakage.

Closes #63.